### PR TITLE
fix:修复编辑角色后没有清空form的menus属性，导致新增时加入了上一个角色的菜单信息

### DIFF
--- a/src/views/system/role/index.vue
+++ b/src/views/system/role/index.vue
@@ -173,8 +173,9 @@ export default {
       this.$refs.menu.setCheckedKeys([])
     },
     // 新增前初始化部门信息
-    [CRUD.HOOK.beforeToAdd]() {
+    [CRUD.HOOK.beforeToAdd](crud, form) {
       this.deptDatas = []
+      form.menus = null
     },
     // 编辑前初始化自定义数据权限的部门信息
     [CRUD.HOOK.beforeToEdit](crud, form) {


### PR DESCRIPTION
编辑角色后，再新增角色时，会导致新角色加入上一个角色的菜单信息，故在新增前清空form的menus属性