### PR TITLE
fix: 树形表格取消父级选择时，删除按钮还能删除子节点问题。

### DIFF
--- a/src/components/Crud/crud.js
+++ b/src/components/Crud/crud.js
@@ -480,6 +480,7 @@ function CRUD(options) {
     toggleRowSelection(selection, data) {
       if (data.children) {
         data.children.forEach(val => {
+          selection.splice(selection.findIndex(item => this.getDataId(item) === this.getDataId(val)), 1)
           crud.getTable().toggleRowSelection(val, false)
           if (val.children) {
             crud.toggleRowSelection(selection, val)


### PR DESCRIPTION
**BUG重现步骤**

1. 打开【系统管理】--> 【菜单管理】
2. 加载【菜单管理】的子节点
3. 选中【菜单管理】
4. 取消选中【菜单管理】

删除按钮显示可用，点击提示【确认删除选中的7条数据?】