### PR TITLE
Fix: 修复手机号码匹配，运营商新增号段如166、191 等开头号码无法通过验证问题

### DIFF
--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -65,7 +65,7 @@ export function validEmail(email) {
 }
 
 export function isvalidPhone(phone) {
-  const reg = /^1[3|4|5|7|8][0-9]\d{8}$/
+  const reg = /^1([38][0-9]|4[014-9]|[59][0-35-9]|6[2567]|7[0-8])\d{8}$/
   return reg.test(phone)
 }
 
@@ -112,7 +112,7 @@ export function validateIP(rule, value, callback) {
 
 /* 是否手机号码或者固话*/
 export function validatePhoneTwo(rule, value, callback) {
-  const reg = /^((0\d{2,3}-\d{7,8})|(1[34578]\d{9}))$/
+  const reg = /^((0\d{2,3}-\d{7,8})|(1([38][0-9]|4[014-9]|[59][0-35-9]|6[2567]|7[0-8])\d{8}))$/
   if (value === '' || value === undefined || value == null) {
     callback()
   } else {
@@ -140,7 +140,7 @@ export function validateTelephone(rule, value, callback) {
 
 /* 是否手机号码*/
 export function validatePhone(rule, value, callback) {
-  const reg = /^[1][3,4,5,7,8][0-9]{9}$/
+  const reg = /^1([38][0-9]|4[014-9]|[59][0-35-9]|6[2567]|7[0-8])\d{8}$/
   if (value === '' || value === undefined || value == null) {
     callback()
   } else {
@@ -165,4 +165,3 @@ export function validateIdNo(rule, value, callback) {
     }
   }
 }
-


### PR DESCRIPTION
## 复现：任何修改手机号码的位置，输入新号段，如166、191 等，均可复现。
![image](https://user-images.githubusercontent.com/20696803/115686113-71cd6580-a38b-11eb-85ee-306c65ba410a.png)

## 修复后效果：
![image](https://user-images.githubusercontent.com/20696803/115686476-d092df00-a38b-11eb-9390-8a7c0f2ac630.png)

#### 附：各大运营商当前（2021年04月22日）可用手机号码段

中国电信号段

`133、153、173、177、180、181、189、190、191、193、199`

中国联通号段

`130、131、132、145、155、156、166、167、171、175、176、185、186、196`

中国移动号段

`134(0-8)、135、136、137、138、139、1440、147、148、150、151、152、157、158、159、172、178、182、183、184、187、188、195、197、198`

中国广电号段

`192`

其他号段

14号段部分为上网卡专属号段：`中国联通145，中国移动147，中国电信149`

虚拟运营商：

电信：`1700、1701、1702、162`
移动：`1703、1705、1706、165`
联通：`1704、1707、1708、1709、171、167`
卫星通信：`1349、174`
物联网：`140、141、144、146、148`