### PR TITLE
修改菜单组件 dialog visible写法问题导致的eslint 警告

### DIFF
--- a/src/views/system/menu/index.vue
+++ b/src/views/system/menu/index.vue
@@ -11,7 +11,7 @@
       <crudOperation :permission="permission" />
     </div>
     <!--表单渲染-->
-    <el-dialog append-to-body :close-on-click-modal="false" :before-close="crud.cancelCU" :visible.sync="crud.status.cu > 0" :title="crud.status.title" width="580px">
+    <el-dialog append-to-body :close-on-click-modal="false" :before-close="crud.cancelCU" :visible="crud.status.cu" :title="crud.status.title" width="580px">
       <el-form ref="form" :inline="true" :model="form" :rules="rules" size="small" label-width="80px">
         <el-form-item label="菜单类型" prop="type">
           <el-radio-group v-model="form.type" size="mini" style="width: 178px">


### PR DESCRIPTION
1.sync修饰符需要一个左值
2dialog的visible可以添加.sync修饰符, 但在这里好像并不需要. 因为visible的值并不需要更新crud.status.cu的值
3crud.status.cu值为0时,js会自动转为false, 值大于0,自动转为true

![image](https://user-images.githubusercontent.com/42304661/135697655-daa89a90-ba33-4e47-813c-71eec17505d6.png)
