### PR TITLE
修复系统工具-代码生成-预览功能，生成预览页面右侧出现双滚动条问题

### DIFF
--- a/src/components/JavaEdit/index.vue
+++ b/src/components/JavaEdit/index.vue
@@ -67,7 +67,6 @@ export default {
   }
   .json-editor >>> .CodeMirror {
     font-size: 14px;
-    overflow-y:auto;
     font-weight:normal
   }
   .json-editor >>> .CodeMirror-scroll{


### PR DESCRIPTION
修复系统工具-代码生成-预览功能，生成预览页面右侧出现双滚动条问题
src\components\JavaEdit\index.vue文件中删除重定义样式，  .json-editor >>> .CodeMirror { overflow: auto}