### PR TITLE
修复富文本编辑器数据双向绑定

### DIFF
--- a/src/components/WangEditor/index.vue
+++ b/src/components/WangEditor/index.vue
@@ -63,12 +63,15 @@ export default {
       },
       editMode: 'simple',
       editor: null,
-      editValue: null
+      editValue: this.value
     }
   },
   watch: {
     editValue(newVal, oldVal) {
       this.$emit('input', newVal)
+    },
+    value(newVal, oldVal) {
+      this.editValue = newVal
     }
   },
   mounted() {


### PR DESCRIPTION
使用v-model对富文本编辑器数据双向绑定的时候：
编辑第一条数据，富文本为第一条数据的内容，编辑第二条数据富文本内容不会更新成第二条数据的内容