### PR TITLE
fix:修复修改密码请求路径问题

### DIFF
--- a/src/api/system/user.js
+++ b/src/api/system/user.js
@@ -39,7 +39,7 @@ export function updatePass(user) {
     newPass: encrypt(user.newPass)
   }
   return request({
-    url: 'api/users/updatePass/',
+    url: 'api/users/updatePass',
     method: 'post',
     data
   })


### PR DESCRIPTION
调用修改密码方法时因为前端末尾多了一个斜杠导致后台系统误认为此请求为静态目录，从而导致NoResourceFoundException异常抛出